### PR TITLE
add publicPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ module.exports = {
         use: {
           loader: 'cpp-wasm-loader',
           options: {
+            publicPath: 'build',
             emccPath: 'path-to-emcc',
             emccFlags: ['-O3']
           }
@@ -70,6 +71,7 @@ The following options can be added to the Webpack loader query:
 
 | Name | Description | Required | Default |
 | ---- | ----------- | -------- | ------- |
+| `publicPath` | Path from which your compiled wasm will be served. Should match `output.publicPath` in your webpack config. | false | '' |
 | `emccPath` | Path to your Emscripten binary (emcc or em++) | false | emcc |
 | `emccFlags` | Array of compilation flags passed to Esmcripten | false | ['-O3'] |
 

--- a/src/options.js
+++ b/src/options.js
@@ -6,8 +6,9 @@ export function loadOptions(loader)
 
   const emccPath = options.emccPath ? options.emccPath : (process.platform === 'win32' ? 'em++.bat' : 'em++');
   const emccFlags = options.emccFlags ? options.emccFlags : ['-O3'];
+  const publicPath = options.publicPath ? options.publicPath : '';
 
   return {
-    emccPath, emccFlags
+    emccPath, emccFlags, publicPath
   };
 }


### PR DESCRIPTION
this is a solution for issue #5
 
i'd love to find a way to access the global `output.publicPath` from the webpack config rather than requiring the user to duplicate it as an option for this loader, but i ran out of patience looking for it, so this is the next best thing.