### PR TITLE
Web worker compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ function minimalEnv(memoryClass) {
 		`}
 
 		var globalEnv = {
-			"global": window,
+			"global": (typeof window !== "undefined" ? window : self),
 			"env": {
 				'_time': function(ptr) {
 					return Date.now();


### PR DESCRIPTION
`window` is not defined in worker context, use `self` instead.